### PR TITLE
mailToが付いていなかったので修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ sasoon
 - Safari
 
 このリポジトリに関するお問い合わせは
-**[吉村　智志](satoshi.yoshimura.so@gmail.com)**
+吉村　智志
+satoshi.yoshimura.so@gmail.com
 まで
 
 


### PR DESCRIPTION
- markdown表記からメールアドレス該当箇所を通常書式に変更
